### PR TITLE
Prevent compiled ACS from being committed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Compiled ACS
+acs/
+
 # Windows image file caches
 Thumbs.db
 ehthumbs.db


### PR DESCRIPTION
Because there is no point to commiting compiled ACS. It can be recompiled from sources.
