### PR TITLE
Make marines unblocked without affecting mops

### DIFF
--- a/Actors/Marine
+++ b/Actors/Marine
@@ -16,6 +16,9 @@ Actor MarinePlayer : DoomPlayer
   damagefactor "bfgsplash", 0
   DamageFactor "MarinePuff", 0
   
+  Species "Player"
+  +THRUSPECIES
+  
   Player.WeaponSlot 1, NewFist, NewChainsaw
   Player.WeaponSlot 2, NewPistol
   Player.WeaponSlot 3, NewShotgun, NewSSG

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,6 @@
 ROP r3:
 
-<Put changes here>
+- Made marines able to go thorugh each other without allowing mops to do so.
 
 ROP r2b:
 


### PR DESCRIPTION
If you set sv_unblockplayers to 1, it makes muppets able to go through each other, but not through real monsters. This decorate trick emulates sv_unblockplayers. Note that sv_unblockplayers should be 0 on  rop servers.
