### PR TITLE
Actor list system

### DIFF
--- a/Actors/Marine
+++ b/Actors/Marine
@@ -1,18 +1,7 @@
 Actor MarinePlayer : DoomPlayer
-{
-  Player.StartItem "NewPistol"
-  Player.StartItem "NewFist"
-  Player.StartItem "Clip", 50
-  
-  Player.StartItem "PistolClip", 12
-  Player.StartItem "ShotgunClip", 8
-  Player.StartItem "ChaingunClip", 40
-  Player.StartItem "SSGClip", 2
-  Player.StartItem "PlasmaClip", 50
-  Player.StartItem "RocketClip", 5
-  
-  Player.StartItem "IsMarine", 1
-  
+{  
+  // For startitems see actorlist.acs
+
   damagefactor "bfgsplash", 0
   DamageFactor "MarinePuff", 0
   

--- a/Src/actorlist.acs
+++ b/Src/actorlist.acs
@@ -1,5 +1,26 @@
-function void InitMonsters(void)
+function void InitMOP(void)
 {
+	AddWeapon("NewFist");
+	AddWeapon("NewPistol");
+	AddWeapon("NewChainsaw");
+	AddWeapon("NewShotgun");
+	AddWeapon("NewSuperShotgun");
+	AddWeapon("NewChaingun");
+	AddWeapon("NewRocketLauncher");
+	AddWeapon("NewPlasmaRifle");
+	AddWeapon("NewBFG9000");
+	AddWeapon("ShieldGenerator");
+	
+	AddStartItem("NewPistol", 1);
+	AddStartItem("Clip", 50);
+	AddStartItem("NewFist", 1);
+	AddStartItem("PistolClip", 12);
+	AddStartItem("ShotgunClip", 8);
+	AddStartItem("ChaingunClip", 40);
+	AddStartItem("SSGClip", 2);
+	AddStartItem("PlasmaClip", 50);
+	AddStartItem("RocketClip", 5);
+	
 	AddMonster(0.02,  "POSSA1",   "Zombieman2", "Zombieman");
 	
 	AddMonster(0.04,  "SPOSA1",   "Shotgunguy2", "Shotgun Zombie");

--- a/Src/arrays.acs
+++ b/Src/arrays.acs
@@ -43,6 +43,7 @@ function void AddStartItem(str actorname, int amount)
 {
 	StartItems[NumStartItems][STARTITEM_ACTORNAME] = actorname;
 	StartItems[NumStartItems][STARTITEM_AMOUNT] = amount;
+	NumStartItems++;
 }
 
 function void AddMonster(int difficulty, str sprite, str actorname, str name)

--- a/Src/arrays.acs
+++ b/Src/arrays.acs
@@ -1,3 +1,5 @@
+// List of all monster types.
+
 #define MONSTER_ACTORNAME 0
 #define MONSTER_DIFFICULTY 1
 #define MONSTER_SCRIPT 2
@@ -10,9 +12,38 @@
 #define MONSTF_FLYING 1
 #define MONSTF_BOSS 2
 
-int NumMonsterTypes = 0;
 #define MAX_MONSTER_TYPES 100
+int NumMonsterTypes = 0;
 int MonsterTypes[MAX_MONSTER_TYPES][NUM_MONSTER_PROPERTIES];
+
+
+// List of all items marine start with.
+
+#define STARTITEM_ACTORNAME 0
+#define STARTITEM_AMOUNT 1
+#define NUM_STARTITEM_PROPERTIES 2
+
+#define MAX_START_ITEMS 32
+int NumStartItems = 0;
+int StartItems[MAX_START_ITEMS][NUM_STARTITEM_PROPERTIES];
+
+
+// List of all weapons marines can use.
+
+#define MAX_MARINE_WEAPONS 32
+int NumMarineWeapons = 0;
+int MarineWeapons[MAX_MARINE_WEAPONS];
+
+function void AddWeapon(str actorname)
+{
+	MarineWeapons[NumMarineWeapons++] = actorname;
+}
+
+function void AddStartItem(str actorname, int amount)
+{
+	StartItems[NumStartItems][STARTITEM_ACTORNAME] = actorname;
+	StartItems[NumStartItems][STARTITEM_AMOUNT] = amount;
+}
 
 function void AddMonster(int difficulty, str sprite, str actorname, str name)
 {
@@ -48,12 +79,12 @@ function void EvadingMonster(int speed)
 
 script mop_count_monstertypes_sv OPEN
 {
-	InitMonsters();
+	InitMOP();
 	//CountMonsterTypes();
 }
 script mop_count_monstertypes_cl OPEN CLIENTSIDE
 {
-	InitMonsters();
+	InitMOP();
 	//CountMonsterTypes();
 }
 

--- a/Src/game.acs
+++ b/Src/game.acs
@@ -59,6 +59,18 @@ function void InitPuppetmasterInventory(void)
 	GiveInventory("AllMap", 1);
 }
 
+function void GiveMarineStartItems(void)
+{
+	GiveInventory("IsMarine", 1);
+	for (int i = 0; i < NumStartItems; i++)
+	{
+		int current = CheckInventory(StartItems[i][STARTITEM_ACTORNAME]);
+		int minimum = StartItems[i][STARTITEM_AMOUNT];
+		if (current < minimum)
+			GiveInventory(StartItems[i][STARTITEM_ACTORNAME], minimum - current);
+	}
+}
+
 script mop_enter ENTER
 {
 	Thing_ChangeTid(0, 1000 + PlayerNumber());
@@ -75,6 +87,7 @@ script mop_enter ENTER
 	{	
 		PlayerClasses[PlayerNumber()] = PLAYER_MARINE;
 		//SetPlayerProperty(0, false, PROP_ALLMAP);
+		
 		if (GetCVar("mop_pistolstart"))
 		{		
 			ClearInventory();
@@ -82,13 +95,13 @@ script mop_enter ENTER
 			for (int i = 0; i < NumMarineWeapons; i++)
 				TakeInventory(MarineWeapons[i], 0x7fffffff);
 				
-			for (i = 0; i < NumStartItems; i++)
-				GiveInventory(StartItems[i][STARTITEM_ACTORNAME], StartItems[i][STARTITEM_AMOUNT]);
-				
-			GiveInventory("IsMarine", 1);
-			
 			SetActorProperty(0, APROP_HEALTH, 100);
-			
+		}
+		
+		GiveMarineStartItems();
+					
+		if (GetCVar("mop_pistolstart"))	
+		{	
 			if (GetCVar("mop_pistolstart") == 1)
 			{
 				print(s:"Pistol Start");
@@ -110,15 +123,6 @@ script mop_enter ENTER
 	ACS_ExecuteAlways(mop_log_join, 0, PlayerNumber(), PlayerClasses[PlayerNumber()], GetCVar("mop_manyplayers")+1);
 	LaunchPlayerScripts();
 	UpdatePlayerCount();
-	
-	if (GetCVar("mop_pistolstart") == 1)
-	{
-		SetWeapon("Pistol");
-	}
-	else if (GetCVar("mop_pistolstart") == 2)
-	{
-		SetWeapon("Shotgun");
-	}
 }
 script mop_respawn RESPAWN
 {
@@ -128,7 +132,7 @@ script mop_respawn RESPAWN
 	LaunchPlayerScripts();
 	
 	if (PlayerClasses[PlayerNumber()] == PLAYER_MARINE)
-		SetWeapon("Handgun"); // WTF is this bug?
+		GiveMarineStartItems();
 	else
 		InitPuppetmasterInventory();
 }

--- a/Src/game.acs
+++ b/Src/game.acs
@@ -79,26 +79,12 @@ script mop_enter ENTER
 		{		
 			ClearInventory();
 			
-			TakeInventory("NewFist", 1);
-			TakeInventory("NewPistol", 1);
-			TakeInventory("NewChainsaw", 1);
-			TakeInventory("NewShotgun", 1);
-			TakeInventory("NewSuperShotgun", 1);
-			TakeInventory("NewChaingun", 1);
-			TakeInventory("NewRocketLauncher", 1);
-			TakeInventory("NewPlasmaRifle", 1);
-			TakeInventory("NewBFG9000", 1);
-			TakeInventory("ShieldGenerator", 1);
-			
-			GiveInventory("NewPistol", 1);
-			GiveInventory("Clip", 30);
-			GiveInventory("NewFist", 1);
-			GiveInventory("PistolClip", 12);
-			GiveInventory("ShotgunClip", 8);
-			GiveInventory("ChaingunClip", 40);
-			GiveInventory("SSGClip", 2);
-			GiveInventory("PlasmaClip", 50);
-			GiveInventory("RocketClip", 5);
+			for (int i = 0; i < NumMarineWeapons; i++)
+				TakeInventory(MarineWeapons[i], 0x7fffffff);
+				
+			for (i = 0; i < NumStartItems; i++)
+				GiveInventory(StartItems[i][STARTITEM_ACTORNAME], StartItems[i][STARTITEM_AMOUNT]);
+				
 			GiveInventory("IsMarine", 1);
 			
 			SetActorProperty(0, APROP_HEALTH, 100);

--- a/Src/mop.acs
+++ b/Src/mop.acs
@@ -72,9 +72,9 @@ int BoomEdition = false;
 
 #define POSSESSED_ADDITIONAL_HP 10000
 
-#include "monsters.acs"
+#include "arrays.acs"
 #include "game.acs"
 #include "evade.acs"
 #include "possess.acs"
-#include "monsterlist.acs"
+#include "actorlist.acs"
 #include "shieldhit.acs"


### PR DESCRIPTION
This is a big update that moves all startitems to actorlist.acs (formerly monsterlist.acs). This eliminates the duplicated startitem list in player class and in the scripts.

It also fixes a weapon desync at the start of the game.

This update may introduce bugs.
